### PR TITLE
Update settings for targets entry, output and devServer

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -38,12 +38,6 @@ This setting is all about where your code is located and where it will be bundle
     source: 'src',
     build: 'dist',
     privateModules: 'private',
-    output: {
-      js: 'statics/js',
-      fonts: 'statics/fonts',
-      css: 'statics/css',
-      images: 'statics/img',
-    },
   }
 }
 ```
@@ -59,10 +53,6 @@ The directory, relative to your project path, where your targets bundled code wi
 ### `privateModules`
 
 This is for the feature that copies when bundling. In case you are using the feature to copy an npm module that, let's say, is not published, woopack will save that module (without its dependencies) on that folder.
-
-### `output`
-
-These are paths for static assets that may be generated when bundling a target.
 
 ## `targetsTemplates`
 
@@ -83,35 +73,26 @@ Since there are a lot of settings for the templates, will divide them by type an
 
 ```js
 {
-  node: {
-    type: 'node',
-    bundle: false,
-    transpile: false,
-    engine: 'webpack',
-    hasFolder: true,
-    createFolder: false,
-    folder: '',
-    entry: {
-      development: 'start.development.js',
-      production: 'start.production.js',
-    },
-    runOnDevelopment: false,
-    babel: {
-      features: [],
-      nodeVersion: 'current',
-      overwrites: {},
-    },
-    flow: false,
-    library: false,
-    libraryOptions: {
-      libraryTarget: 'commonjs2',
-    },
-    cleanBeforeBuild: true,
-  }
+  type: 'node',
+  bundle: false,
+  transpile: false,
+  engine: 'webpack',
+  hasFolder: true,
+  createFolder: false,
+  folder: '',
+  entry: { ... },
+  output: { ... },
+  runOnDevelopment: false,
+  babel: { ... },
+  flow: false,
+  library: false,
+  libraryOptions: { ... },
+  cleanBeforeBuild: true,
 }
 ```
 
 #### `bundle`
+> Default value: `false`
 
 Whether or not the target needs to be bundled. Yes, it's kind of ironic that a tool that aims to simplify bundling would have an option like this, but there are a few scenarios where this may be useful:
 
@@ -121,38 +102,75 @@ Whether or not the target needs to be bundled. Yes, it's kind of ironic that a t
 If the value is `false`, when running on a development environment, and if the target doesn't need transpilation, the code won't be moved to the distribution directory.
 
 #### `transpile`
+> Default value: `false`
 
 This option is kind of tied to the previous one: You may not want to bundle your Node target, but you can transpile it with [Babel](https://babeljs.io) if you want to use a feature not yet supported by the runtime.
 
 #### `engine`
+> Default value: `webpack`
 
 In case `bundle` is `true`, this will tell woopack which build engine you are going to bundle the target code with.
 
 > If you don't intend to change its default value, you need to have the package [`woopack-plugin-webpack`](https://yarnpkg.com/en/package/woopack-plugin-webpack) installed.
 
 #### `hasFolder`
+> Default value: `true`
 
 Whether your target code is on a sub folder of the source directory (`src/[target-name]/`) or the contents of the source directory are your target code (useful when working with a single target).
 
 #### `createFolder`
+> Default value: `false`
 
 Whether or not to create a folder for your targets code on the distribution directory when the target is bundled/copied.
 
 #### `folder`
+> Default value: `''`
 
 If either `hasFolder` or `createFolder` is `true`, this can be used to specify a different folder name than the target's name.
 
 #### `entry`
+> Default value
+>
+> ```js
+> {
+>   default: 'index.js',
+>   development: null,
+>   production: null,
+> }
+> ```
 
-This object with the keys `development` and `production` tells woopack which is the main file (executable) of your target for each environment.
+This object is the one that tells woopack which is the main file (executable) of your target for each specific environment. If you set `null` to an entry for an specific environment, it will fallback to the value of the `default` setting.
+
+#### `output`
+> Default value:
+>
+> ```js
+> {
+>   default: '[target-name].js',
+>   development: null,
+>   production: null,
+> }
+> ```
+
+This tells woopack where to place the generated bundle on each environment. You can also use the `[target-name]` placeholder on the paths.
 
 #### `runOnDevelopment`
+> Default value: `false`
 
 This tells woopack that when the target is builded (bundled/copied) on a development environment, it should execute it.
 
 When the target needs to be bundled, it will relay on the build engined to do it, otherwise, woopack will use its custom implementation of [`nodemon`](https://yarnpkg.com/en/package/nodemon) for watching and, if needed, transpile your target code.
 
 #### `babel`
+> Default value:
+>
+> ```js
+> {
+>   features: [],
+>   nodeVersion: 'current',
+>   overwrites: {},
+> }
+> ```
 
 These options are used in the case the target needs to be bundled or transpile to configure [Babel](https://babeljs.io):
 
@@ -171,107 +189,155 @@ When building the Babel configuration, woopack uses the [`babel-preset-env`](htt
 If you know how to use Babel and need stuff that is not covered by woopack, you can use this setting to overwrite/add any value you may need.
 
 #### `flow`
+> Default value: `false`
 
 Whether or not your target uses [flow](https://flow.org/). This will update the Babel configuration in order to add support and, in case it was disabled, it will enable transpilation.
 
 #### `library`
+> Default value: `false`
 
 If the project is bundled, this will tell the build engine that it needs to be builded as a library to be `require`d.
 
 #### `libraryOptions`
+> Default value:
+>
+> ```js
+> {
+>   libraryTarget: 'commonjs2',
+> }
+> ```
 
 In case `library` is `true`, these options are going to be used by the build engine to configure your library:
 
 **`libraryOptions.libraryTarget`**
 
-How the library will be exposed: `commonjs2`, `umd` and `window`.
+How the library will be exposed: `commonjs2`, `umd` or `window`.
 
 > Since this was built based on the webpack API, if you are using it as a build engine, you can set any `libraryTarget` that webpack supports. The ones mentioned above will be the ones woopack will support for all the other build engines with different APIs.
 
 #### `cleanBeforeBuild`
+> Default value: `true`
 
 Whether or not to remove all code from previous builds from the distribution directory when making a new build.
 
 ### `browser`
 
 ```js
-browser: {
+{
   type: 'browser',
   engine: 'webpack',
   hasFolder: true,
   createFolder: true,
   folder: '',
-  entry: {
-    development: 'index.js',
-    production: 'index.js',
-  },
-  sourceMap: {
-    development: false,
-    production: true,
-  },
-  html: {
-    template: 'index.html',
-    filename: 'index.html',
-  },
+  entry: { ... },
+  output: { ... },
+  sourceMap: { ... },
+  html: { ... },
   runOnDevelopment: false,
-  babel: {
-    features: [],
-    browserVersions: 2,
-    mobileSupport: true,
-    polyfill: true,
-    overwrites: {},
-  },
+  babel: { ... },
   flow: false,
   CSSModules: false,
   library: false,
-  libraryOptions: {},
+  libraryOptions: { ... },
   cleanBeforeBuild: true,
-  devServer: {
-    port: 2509,
-    reload: true,
-  },
-  configuration: {
-    enabled: false,
-    default: null,
-    path: 'config/',
-    hasFolder: true,
-    defineOn: 'process.env.CONFIG',
-    environmentVariable: 'CONFIG',
-    loadFromEnvironment: true,
-    filenameFormat: '[target-name].[configuration-name].config.js',
-  },
+  devServer: { ... },
+  configuration: { ... },
 }
 ```
 
 #### `engine`
+> Default value: `webpack`
 
 This will tell woopack which build engine you are going to bundle the target code with.
 
 > If you don't intend to change its default value, you need to have the package [`woopack-plugin-webpack`](https://yarnpkg.com/en/package/woopack-plugin-webpack) installed.
 
 #### `hasFolder`
+> Default value: `true`
 
 Whether your target code is on a sub folder of the source directory (`src/[target-name]/`) or the contents of the source directory are your target code (useful when working with a single target).
 
 #### `createFolder`
+> Default value: `false`
 
 Whether or not to create a folder for your targets code on the distribution directory when the target is bundled/copied.
 
 #### `folder`
+> Default value: `''`
 
 If either `hasFolder` or `createFolder` is `true`, this can be used to specify a different folder name than the target's name.
 
 #### `entry`
+> Default value
+>
+> ```js
+> {
+>   default: 'index.js',
+>   development: null,
+>   production: null,
+> }
+> ```
 
-This object with the keys `development` and `production` tells woopack which is the main file (executable) of your target for each environment.
+This object is the one that tells woopack which is the main file (the one that fires the app) of your target for each specific environment. If you set `null` to an entry for an specific environment, it will fallback to the value of the `default` setting.
+
+#### `output`
+> Default value:
+>
+> ```js
+> {
+>   default: {
+>     js: 'statics/js/[target-name].[hash].js',
+>     fonts: 'statics/fonts/[name].[hash].[ext]',
+>     css: 'statics/styles/[target-name].[hash].css',
+>     images: 'statics/images/[name].[hash].[ext]',
+>   },
+>   development: {
+>     js: 'statics/js/[target-name].js',
+>     fonts: 'statics/fonts/[name].[ext]',
+>     css: 'statics/styles/[target-name].css',
+>     images: 'statics/images/[name].[ext]',
+>   },
+>   production: null,
+> }
+> ```
+
+This tells woopack where to place the files generated while bundling on each environment, depending on the file type.
+
+You can use the following placeholders:
+
+- `[target-name]`: The name of the target.
+- `[hash]`: A random hash generated for cache busting.
+- `[name]`: The file original name (Not available for `css` and `js`).
+- `[ext]`: The file original extension (Not available for `css` and `js`).
 
 #### `sourceMap`
+> Default value:
+>
+> ```js
+> {
+>   development: false,
+>   production: true,
+> }
+> ```
 
 Whether or not to disable source map generation for each environment.
 
 #### `html`
+> Default value:
+>
+> ```js
+> {
+>   default: 'index.html',
+>   template: null,
+>   filename: null,
+> }
+> ```
 
 In the case the target is an app, these are the options for the `html` file that will include the bundle `<script />`; and if your target is a library, this can be used to test your library.
+
+**`html.default`**
+
+This would be the fallback if either `template` or `filename` is `null`.
 
 **`html.template`**
 
@@ -282,10 +348,22 @@ The file inside your target source that will be used to generate the `html`.
 The file that will be generated when your target is bundled. It will automatically include the `<script />` tag to the generated bundle.
 
 #### `runOnDevelopment`
+> Default value: `false`
 
 This will tell the build engine that when you build the target for a development environment, it should bring up an `http` server to _"run"_ your target.
 
 #### `babel`
+> Default value:
+>
+> ```js
+> {
+>   features: [],
+>   browserVersions: 2,
+>   mobileSupport: true,
+>   polyfill: true,
+>   overwrites: {},
+> }
+> ```
 
 These options are used by the build engine to configure [Babel](https://babeljs.io):
 
@@ -314,32 +392,53 @@ Whether or not the configuration should include the [`babel-polyfill`](https://y
 If you know how to use Babel and need stuff that is not covered by woopack, you can use this setting to overwrite/add any value you may need.
 
 #### `flow`
+> Default value: `false`
 
 Whether or not your target uses [flow](https://flow.org/). This will update the Babel configuration in order to add support for it.
 
 #### `CSSModules`
+> Default value: `false`
 
 Whether or not your application uses CSS Modules.
 
 #### `library`
+> Default value: `false`
 
 This will tell the build engine that it needs to be builded as a library to be `require`d.
 
 #### `libraryOptions`
+> Default value:
+>
+> ```js
+> {
+>   libraryTarget: 'umd',
+> }
+> ```
 
 In case `library` is `true`, these options are going to be used by the build engine to configure your library:
 
 **`libraryOptions.libraryTarget`**
 
-How the library will be exposed: `commonjs`, `umd` and `window`.
+How the library will be exposed: `commonjs`, `umd` or `window`.
 
 > Since this was built based on the webpack API, if you are using it as a build engine, you can set any `libraryTarget` that webpack supports. The ones mentioned above will be the ones woopack will support for all the other build engines with different APIs.
 
 #### `cleanBeforeBuild`
+> Default value: `true`
 
 Whether or not to remove all code from previous builds from the distribution directory when making a new build.
 
 #### `devServer`
+> Default value:
+>
+> ```js
+> {
+>   port: 2509,
+>   reload: true,
+>   host: 'localhost',
+>   https: false,
+> }
+> ```
 
 These are the options for the `http` server woopack will use when running the target on a development environment.
 
@@ -351,7 +450,29 @@ The server port.
 
 Whether or not to reload the server when the code changes.
 
+**`devServer.host`**
+
+The dev server hostname.
+
+**`devServer.https`**
+
+Whether or not the dev server host protocol should be `https`.
+
 #### `configuration`
+> Default value:
+>
+> ```js
+> {
+>   enabled: false,
+>   default: null,
+>   path: 'config/',
+>   hasFolder: true,
+>   defineOn: 'process.env.CONFIG',
+>   environmentVariable: 'CONFIG',
+>   loadFromEnvironment: true,
+>   filenameFormat: '[target-name].[configuration-name].config.js',
+> }
+> ```
 
 These are the settings for the feature that allows a browser target to have a dynamic configuration file.
 
@@ -412,39 +533,47 @@ These settings are for the feature that enables woopack to copy files when build
 
 ```js
 {
-  copy: {
-    enabled: false,
-    items: [],
-    copyOnBuild: {
-      enabled: true,
-      onlyOnProduction: true,
-      targets: [],
-    },
-  }
+  enabled: false,
+  items: [],
+  copyOnBuild: { ... },
 }
 ```
 
 ### `enabled`
+> Default value: `false`
 
 Whether or not the feature is enabled.
 
 ### `items`
+> Default value: `[]`
 
 A list of files and/or directories that will be copied. All with paths relative to the project directory.
 
 ### `copyOnBuild`
+> Default value:
+>
+> ```js
+> {
+>   enabled: true,
+>   onlyOnProduction: true,
+>   targets: [],
+> }
+> ```
 
 Since the feature is also available through the woopack CLI, you can configure how the feature behaves when building:
 
-#### `enabled`
+#### `copyOnBuild.enabled`
+> Default value: `true`
 
 Whether or not to copy the files when building. If disabled, you can use the CLI to copy the files.
 
-#### `onlyOnProduction`
+#### `copyOnBuild.onlyOnProduction`
+> Default value: `true`
 
 This tells woopack if the files should be copied only when building for production, or if it should do it for development too.
 
-#### `targets`
+#### `copyOnBuild.targets`
+> Default value: `[]`
 
 This can be used to specify the targets that will trigger the feature when builded. If no target is specified, the feature will be triggered by all the targets.
 
@@ -454,62 +583,79 @@ These settings are for the feature that manages your project version:
 
 ```js
 {
-  version: {
-    defineOne: 'APP_VERSION',
-    environmentVariable: 'VERSION',
-    revision: {
-      enabled: false,
-      copy: true,
-      filename: 'revision',
-      createRevisionOnBuild: {
-        enabled: true,
-        onlyOnProduction: true,
-        targets: [],
-      },
-    },
-  }
+  defineOn: 'process.env.VERSION',
+  environmentVariable: 'VERSION',
+  revision: { ... },
 }
 ```
 
-### `defineOne`
+### `defineOn`
+> Default value: `process.env.VERSION`
 
 The name of the variable where the version is going to be replaced on your code when bundled.
 
 ### `environmentVariable`
+> Default value: `VERSION`
 
 The name of the environment variable woopack should check to get the project version.
 
 ### `revision`
+> Default value:
+>
+> ```js
+> {
+>   enabled: false,
+>   copy: true,
+>   filename: 'revision',
+>   createRevisionOnBuild: { ... },
+> }
+> ```
 
 This is like a sub-feature. A revision file is a file that contains the version of your project. This is useful when deploying the project to an environment where you have no access to the environment variable.
 
 The way the revision file works is by first checking if the environment variable is available and, if not, it will check if the project is on a `GIT` repository and try to get the hash of the last commit.
 
 #### `revision.enabled`
+> Default value: `false`
 
 Whether or not the revision file feature is enabled.
 
 #### `revision.copy`
+> Default value: `false`
 
 Whether or not to copy the revision file when the project files are being copied to the distribution directory.
 
 #### `revision.filename`
+> Default value: `revision`
 
 The name of the revision file.
 
 #### `revision.createRevisionOnBuild`
+> Default value:
+>
+> ```js
+> {
+>   enabled: true,
+>   onlyOnProduction: true,
+>   targets: [],
+> }
+> ```
+
 
 Since the feature is also available through the woopack CLI, you can configure how the feature behaves when building:
 
 **`revision.createRevisionOnBuild.enabled`**
+> Default value: `true`
 
 Whether or not to create the file when building. If disabled, you can use the CLI to copy the files.
 
 **`revision.createRevisionOnBuild.onlyOnProduction`**
+> Default value: `true`
 
 This tells woopack if the file should be created only when building for production, or if it should do it for development too.
 
 **`revision.createRevisionOnBuild.targets`**
+> Default value: `[]`
 
 This can be used to specify the targets that will trigger the feature when builded. If no target is specified, the feature will be triggered by all the targets.
 
@@ -517,12 +663,26 @@ This can be used to specify the targets that will trigger the feature when build
 
 Miscellaneous options.
 
+```js
+{
+  watch: { .. },
+}
+```
+
 ### `watch`
+> Default value:
+>
+> ```js
+> {
+>   poll: true,
+> }
+> ```
 
 This is used by woopack to configure [`watchpack`](https://yarnpkg.com/en/package/watchpack), which is used to watch Node files that need to be transpiled.
 
 The reason is outside the `targetsTemplate.node` is because this can be used for any other plugin that watches the file system.
 
 #### `watch.poll`
+> Default value: `true`
 
 Whether or not to use polling to get the changes on the file system, and if so, it can also be used to specify the ms interval.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "wootils": "^1.0.5",
+      "wootils": "^1.1.1",
       "jimple": "homer0/jimple",
       "fs-extra": "5.0.0",
       "extend": "3.0.1",

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -26,12 +26,6 @@ class ProjectConfiguration extends ConfigurationFile {
         source: 'src',
         build: 'dist',
         privateModules: 'private',
-        output: {
-          js: 'statics/js',
-          fonts: 'statics/fonts',
-          css: 'statics/css',
-          images: 'statics/img',
-        },
       },
       targetsTemplates: {
         node: {
@@ -43,8 +37,14 @@ class ProjectConfiguration extends ConfigurationFile {
           createFolder: false,
           folder: '',
           entry: {
-            development: 'start.development.js',
-            production: 'start.production.js',
+            default: 'index.js',
+            development: null,
+            production: null,
+          },
+          output: {
+            default: '[target-name].js',
+            development: null,
+            production: null,
           },
           runOnDevelopment: false,
           babel: {
@@ -54,7 +54,9 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           flow: false,
           library: false,
-          libraryOptions: {},
+          libraryOptions: {
+            libraryTarget: 'commonjs2',
+          },
           cleanBeforeBuild: true,
         },
         browser: {
@@ -64,16 +66,33 @@ class ProjectConfiguration extends ConfigurationFile {
           createFolder: true,
           folder: '',
           entry: {
-            development: 'index.js',
-            production: 'index.js',
+            default: 'index.js',
+            development: null,
+            production: null,
+          },
+          output: {
+            default: {
+              js: 'statics/js/[target-name].[hash].js',
+              fonts: 'statics/fonts/[name].[hash].[ext]',
+              css: 'statics/styles/[target-name].[hash].css',
+              images: 'statics/images/[name].[hash].[ext]',
+            },
+            development: {
+              js: 'statics/js/[target-name].js',
+              fonts: 'statics/fonts/[name].[ext]',
+              css: 'statics/styles/[target-name].css',
+              images: 'statics/images/[name].[ext]',
+            },
+            production: null,
           },
           sourceMap: {
             development: false,
             production: true,
           },
           html: {
-            template: 'index.html',
-            filename: 'index.html',
+            default: 'index.html',
+            template: null,
+            filename: null,
           },
           runOnDevelopment: false,
           babel: {
@@ -85,13 +104,17 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           flow: false,
           CSSModules: false,
-          hotReload: false,
+          hot: false,
           library: false,
-          libraryOptions: {},
+          libraryOptions: {
+            libraryTarget: 'umd',
+          },
           cleanBeforeBuild: true,
           devServer: {
             port: 2509,
             reload: true,
+            host: 'localhost',
+            https: false,
           },
           configuration: {
             enabled: false,

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -1,4 +1,10 @@
 /**
+ * ================================================================================================
+ * Externals
+ * ================================================================================================
+ */
+
+/**
  * @external {Jimple}
  * https://yarnpkg.com/en/package/jimple
  */
@@ -54,9 +60,9 @@
  */
 
 /**
- * @typedef {Object} TargetLibraryOptions
- * @property {string} [libraryTarget='commonjs2']
- * How the library will be exposed: `commonjs2`, `umd` and `window`
+ * ================================================================================================
+ * Project configuration > Targets > sub properties > Shared
+ * ================================================================================================
  */
 
 /**
@@ -86,8 +92,51 @@
  */
 
 /**
- * @typedef {Object} NodeTargetBabelSettings
- * @property {Array}  [features=[]]
+ * ================================================================================================
+ * Project configuration > Targets templates > Sub properties > Shared
+ * ================================================================================================
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationTargetTemplateEntry
+ * @property {string} [default='index.js']
+ * The target entry file for all types of build that don't have a specified entry.
+ * @property {string} [development=null]
+ * The target entry file on a development build. If `null`, it will fallback to the one specified
+ * on `default`.
+ * @property {string} [production=null]
+ * The target entry file on a production build. If `null`, it will fallback to the one specified
+ * on `default`.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationTargetTemplateLibraryOptions
+ * @property {string} [libraryTarget='commonjs2']
+ * How the library will be exposed: `commonjs2`, `umd` and `window`
+ */
+
+/**
+ * ================================================================================================
+ * Project configuration > Targets templates > Sub properties > Node
+ * ================================================================================================
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationNodeTargetTemplateOutput
+ * @property {string} [default='[target-name].js']
+ * The target output file path for all types of build that are not specified. The only available
+ * placeholder is `[target-name]`.
+ * @property {string} [development=null]
+ * The target output file path on a development build. If `null`, it will fallback to the
+ * `default`. The only available placeholder is `[target-name]`.
+ * @property {string} [production=null]
+ * The target output file path on a production build. If `null`, it will fallback to the `default`.
+ * The only available placeholder is `[target-name]`.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationNodeTargetTemplateBabelSettings
+ * @property {Array} [features=[]]
  * woopack includes by default two Babel plugins: `transform-class-properties` and
  * `transform-decorators-legacy`. On this list you can use the values `properties` or `decorators`
  * to include them.
@@ -101,8 +150,103 @@
  */
 
 /**
- * @typedef {Object} BrowserTargetBabelSettings
- * @property {Array}  [features=[]]
+ * ================================================================================================
+ * Project configuration > Targets templates > Sub properties > Browser
+ * ================================================================================================
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateDevelopmentOutputPaths
+ * @property {string} [js='statics/js/[target-name].js']
+ * The path to generated Javascript files on the distribution directory. The available placeholders
+ * are:
+ * - `[target-name]`: The name of the target.
+ * - `[hash]`: A random hash generated for cache busting.
+ * @property {string} [fonts='statics/fonts/[name].[ext]']
+ * The path to font files once they are copied to the distribution directory. The available
+ * placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[name]`: The file original name.
+ * - `[ext]`: The file original extension.
+ * - `[hash]`: A random hash generated for cache busting.
+ * @property {string} [css='statics/styles/[name].css']
+ * The path to generated stylesheets on the distribution directory. The available placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[hash]`: A random hash generated for cache busting.
+ * @property {string} [fonts='statics/images/[name].[ext]']
+ * The path to image files once they are copied to the distribution directory. The available
+ * placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[name]`: The file original name.
+ * - `[ext]`: The file original extension.
+ * - `[hash]`: A random hash generated for cache busting.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateProductionOutputPaths
+ * @property {string} [js='statics/js/[target-name].[hash].js']
+ * The path to generated Javascript files on the distribution directory. The available placeholders
+ * are:
+ * - `[target-name]`: The name of the target.
+ * - `[hash]`: A random hash generated for cache busting.
+ * @property {string} [fonts='statics/fonts/[name].[hash].[ext]']
+ * The path to font files once they are copied to the distribution directory. The available
+ * placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[name]`: The file original name.
+ * - `[ext]`: The file original extension.
+ * - `[hash]`: A random hash generated for cache busting.
+ * @property {string} [css='statics/styles/[target-name].[hash].css']
+ * The path to generated stylesheets on the distribution directory. The available placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[hash]`: A random hash generated for cache busting.
+ * @property {string} [fonts='statics/images/[name].[hash].[ext]']
+ * The path to image files once they are copied to the distribution directory. The available
+ * placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[name]`: The file original name.
+ * - `[ext]`: The file original extension.
+ * - `[hash]`: A random hash generated for cache busting.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateOutput
+ * @property {ProjectConfigurationBrowserTargetTemplateProductionOutputPaths} [default]
+ * The target output settings for all types of build that don't have specified settings.
+ * @property {ProjectConfigurationBrowserTargetTemplateDevelopmentOutputPaths} [development]
+ * The target output settings on a development build. If `null`, it will fallback to the ones
+ * specified on `default`.
+ * @property {ProjectConfigurationBrowserTargetTemplateProductionOutputPaths} [production=null]
+ * The target output settings on a production build. If `null`, it will fallback to the ones
+ * specified on `default`.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateSourceMapSettings
+ * @property {boolean} [development=false]
+ * Whether or not to generate a source map on a development build.
+ * @property {boolean} [production=true]
+ * Whether or not to generate a source map on a production build.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateHTMLSettings
+ * @property {string} [default='index.html']
+ * This setting can be used to set the same value of default `template` and `filename` at once. But
+ * it will only overwrite settings with a `null` value, if one is specified, the value of this
+ * setting will be ignored.
+ * @property {string} [template=null]
+ * The file inside your target source that will be used to generate the `html`. If `null`, it will
+ * fallback to the value of the `default` setting.
+ * @property {string} [filename=null]
+ * The file that will be generated when your target is bundled. It will automatically include
+ * the `<script />` tag to the generated bundle. If `null`, it will fallback to the value of the
+ * `default` setting.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateBabelSettings
+ * @property {Array} [features=[]]
  * woopack includes by default two Babel plugins: `transform-class-properties` and
  * `transform-decorators-legacy`. On this list you can use the values `properties` or `decorators`
  * to include them.
@@ -122,15 +266,19 @@
  */
 
 /**
- * @typedef {Object} BrowserTargetDevServerSettings
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateDevServerSettings
  * @property {number} [port=2509]
  * The server port.
  * @property {boolean} [reload=true]
  * Whether or not to reload the server when the code changes.
+ * @property {string} [host='localhost']
+ * The dev server hostname.
+ * @property {boolean} [https=false]
+ * Whether or not the dev server host protocol should be `https`.
  */
 
 /**
- * @typedef {Object} BrowserTargetConfigurationSettings
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateConfigurationSettings
  * @property {boolean} [enabled=false]
  * Whether or not the feature is enabled.
  * @property {null|Object} [default=null]
@@ -153,39 +301,9 @@
  */
 
 /**
- * @typedef {Object} ProjectConfigurationOutputPathSettings
- * @property {string} [js='static/js']
- * The path to generated Javascript files on the distribution directory.
- * @property {string} [fonts='static/fonts']
- * The path to font files once they are moved to the distribution directory.
- * @property {string} [css='static/css']
- * The path to generated stylesheets on the distribution directory.
- * @property {string} [images='static/img']
- * The path to font files once they are moved to the distribution directory.
- */
-
-/**
- * @typedef {Object} ProjectConfigurationPathSettings
- * @property {string} [source='src']
- * The directory, relative to your project path, where your targets code is located. On the
- * documentation is often referred as the _"source directory"_.
- * @property {string} [build='dist']
- * The directory, relative to your project path, where your targets bundled code will be located.
- * On the documentation is often referred as the _"distribution directory"_.
- * @property {string} [privateModules='private']
- * This is for the feature that copies when bundling. In case you are using the feature to copy an
- * npm module that, let's say, is not published, woopack will save that module (without its
- * dependencies) on that folder.
- * @property {ProjectConfigurationOutputPathSettings} [output]
- * These are paths for static assets that may be generated when bundling a target.
- */
-
-/**
- * @typedef {Object} ProjectConfigurationNodeTargetTemplateEntries
- * @property {string} [development='start.development.js']
- * The target entry point on a development build.
- * @property {string} [production='start.production.js']
- * The target entry point on a production build.
+ * ================================================================================================
+ * Project configuration > Targets and target templates > Node
+ * ================================================================================================
  */
 
 /**
@@ -211,12 +329,14 @@
  * @property {string} [folder='']
  * If either `hasFolder` or `createFolder` is `true`, this can be used to specify a different
  * folder name than the target's name.
- * @property {ProjectConfigurationNodeTargetTemplateEntries} [entry]
- * The target entry points for each specific environment build.
+ * @property {ProjectConfigurationTargetTemplateEntry} [entry]
+ * The target entry files for each specific build type.
+ * @property {ProjectConfigurationNodeTargetTemplateOutput} [output]
+ * The target file paths for each specific build type.
  * @property {boolean} [runOnDevelopment=false]
  * This tells woopack that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
- * @property {NodeTargetBabelSettings} [babel]
+ * @property {ProjectConfigurationNodeTargetTemplateBabelSettings} [babel]
  * The target transpilation options.
  * @property {boolean} [flow=false]
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
@@ -224,7 +344,7 @@
  * @property {boolean} [library=false]
  * If the project is bundled, this will tell the build engine that it needs to be builded as a
  * library to be `require`d.
- * @property {TargetLibraryOptions} [libraryOptions]
+ * @property {ProjectConfigurationTargetTemplateLibraryOptions} [libraryOptions]
  * In case `library` is `true`, these options are going to be used by the build engine to configure
  * your library
  * @property {boolean} [cleanBeforeBuild=true]
@@ -255,12 +375,14 @@
  * @property {string} folder
  * If either `hasFolder` or `createFolder` is `true`, this can be used to specify a different
  * folder name than the target's name.
- * @property {ProjectConfigurationNodeTargetTemplateEntries} entry
- * The target entry points for each specific environment build.
+ * @property {ProjectConfigurationTargetTemplateEntry} entry
+ * The target entry files for each specific build type.
+ * @property {ProjectConfigurationNodeTargetTemplateOutput} output
+ * The target file paths for each specific build type.
  * @property {boolean} runOnDevelopment
  * This tells woopack that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
- * @property {NodeTargetBabelSettings} babel
+ * @property {ProjectConfigurationNodeTargetTemplateBabelSettings} babel
  * The target transpilation options.
  * @property {boolean} flow
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
@@ -268,7 +390,7 @@
  * @property {boolean} library
  * If the project is bundled, this will tell the build engine that it needs to be builded as a
  * library to be `require`d.
- * @property {TargetLibraryOptions} libraryOptions
+ * @property {ProjectConfigurationTargetTemplateLibraryOptions} libraryOptions
  * In case `library` is `true`, these options are going to be used by the build engine to configure
  * your library
  * @property {boolean} cleanBeforeBuild
@@ -285,28 +407,9 @@
  */
 
 /**
- * @typedef {Object} ProjectConfigurationBrowserTargetTemplateEntries
- * @property {string} [development='index.js']
- * The target entry point on a development build.
- * @property {string} [production='index.js']
- * The target entry point on a production build.
- */
-
-/**
- * @typedef {Object} ProjectConfigurationBrowserTargetTemplateSourceMapSettings
- * @property {boolean} [development=false]
- * Whether or not to generate a source map on a development build.
- * @property {boolean} [production=true]
- * Whether or not to generate a source map on a production build.
- */
-
-/**
- * @typedef {Object} ProjectConfigurationBrowserTargetTemplateHTMLSettings
- * @property {string} [template='index.html']
- * The file inside your target source that will be used to generate the `html`.
- * @property {string} [filename='index.html']
- * The file that will be generated when your target is bundled. It will automatically include
- * the `<script />` tag to the generated bundle.
+ * ================================================================================================
+ * Project configuration > Targets and target templates > Browser
+ * ================================================================================================
  */
 
 /**
@@ -323,8 +426,10 @@
  * @property {string} [folder='']
  * If either `hasFolder` or `createFolder` is `true`, this can be used to specify a different
  * folder name than the target's name.
- * @property {ProjectConfigurationBrowserTargetTemplateEntries} [entry]
- * The target entry points for each specific environment build.
+ * @property {ProjectConfigurationTargetTemplateEntry} [entry]
+ * The target entry files for each specific build type.
+ * @property {ProjectConfigurationBrowserTargetTemplateOutput} [output]
+ * The target output settings for each specific build type.
  * @property {ProjectConfigurationBrowserTargetTemplateSourceMapSettings} [sourceMap]
  * The target source map settings for each specific environment build.
  * @property {ProjectConfigurationBrowserTargetTemplateHTMLSettings} [html]
@@ -333,7 +438,7 @@
  * @property {boolean} [runOnDevelopment=false]
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.
- * @property {BrowserTargetBabelSettings} [babel]
+ * @property {ProjectConfigurationBrowserTargetTemplateBabelSettings} [babel]
  * These options are used by the build engine to configure [Babel](https://babeljs.io):
  * @property {boolean} [flow=false]
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
@@ -342,16 +447,16 @@
  * Whether or not your application uses CSS Modules.
  * @property {boolean} [library=false]
  * This will tell the build engine that it needs to be builded as a library to be `require`d.
- * @property {TargetLibraryOptions} [libraryOptions]
+ * @property {ProjectConfigurationTargetTemplateLibraryOptions} [libraryOptions]
  * In case `library` is `true`, these options are going to be used by the build engine to configure
  * your library.
  * @property {boolean} [cleanBeforeBuild=true]
  * Whether or not to remove all code from previous builds from the distribution directory when
  * making a new build.
- * @property {BrowserTargetDevServerSettings} [devServer]
+ * @property {ProjectConfigurationBrowserTargetTemplateDevServerSettings} [devServer]
  * These are the options for the `http` server woopack will use when running the target on a
  * development environment.
- * @property {BrowserTargetConfigurationSettings} [configuration]
+ * @property {ProjectConfigurationBrowserTargetTemplateConfigurationSettings} [configuration]
  * These are the settings for the feature that allows a browser target to have a dynamic
  * configuration file.
  */
@@ -370,8 +475,10 @@
  * @property {string} folder
  * If either `hasFolder` or `createFolder` is `true`, this can be used to specify a different
  * folder name than the target's name.
- * @property {ProjectConfigurationBrowserTargetTemplateEntries} entry
- * The target entry points for each specific environment build.
+ * @property {ProjectConfigurationTargetTemplateEntry} entry
+ * The target entry files for each specific build type.
+ * @property {ProjectConfigurationBrowserTargetTemplateOutput} output
+ * The target output settings for each specific build type.
  * @property {ProjectConfigurationBrowserTargetTemplateSourceMapSettings} sourceMap
  * The target source map settings for each specific environment build.
  * @property {ProjectConfigurationBrowserTargetTemplateHTMLSettings} html
@@ -380,7 +487,7 @@
  * @property {boolean} runOnDevelopment
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.
- * @property {BrowserTargetBabelSettings} babel
+ * @property {ProjectConfigurationBrowserTargetTemplateBabelSettings} babel
  * These options are used by the build engine to configure [Babel](https://babeljs.io):
  * @property {boolean} flow
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
@@ -389,16 +496,16 @@
  * Whether or not your application uses CSS Modules.
  * @property {boolean} library
  * This will tell the build engine that it needs to be builded as a library to be `require`d.
- * @property {TargetLibraryOptions} libraryOptions
+ * @property {ProjectConfigurationTargetTemplateLibraryOptions} libraryOptions
  * In case `library` is `true`, these options are going to be used by the build engine to configure
  * your library.
  * @property {boolean} cleanBeforeBuild
  * Whether or not to remove all code from previous builds from the distribution directory when
  * making a new build.
- * @property {BrowserTargetDevServerSettings} devServer
+ * @property {ProjectConfigurationBrowserTargetTemplateDevServerSettings} devServer
  * These are the options for the `http` server woopack will use when running the target on a
  * development environment.
- * @property {BrowserTargetConfigurationSettings} configuration
+ * @property {ProjectConfigurationBrowserTargetTemplateConfigurationSettings} configuration
  * These are the settings for the feature that allows a browser target to have a dynamic
  * configuration file.
  * @property {TargetTypeCheck} is
@@ -412,16 +519,23 @@
  */
 
 /**
- * @typedef {BrowserTarget|NodeTarget} Target
+ * ================================================================================================
+ * Project configuration & Sub properties
+ * ================================================================================================
  */
 
 /**
- * @typedef {function} TargetConfigurationCreator
- * @param {string} overwritePath
- * The path to the file that can create the configuration.
- * @param {ConfigurationFile} baseConfiguration
- * The configuration service that will be extended.
- * @return {ConfigurationFile}
+ * @typedef {Object} ProjectConfigurationPathSettings
+ * @property {string} [source='src']
+ * The directory, relative to your project path, where your targets code is located. On the
+ * documentation is often referred as the _"source directory"_.
+ * @property {string} [build='dist']
+ * The directory, relative to your project path, where your targets bundled code will be located.
+ * On the documentation is often referred as the _"distribution directory"_.
+ * @property {string} [privateModules='private']
+ * This is for the feature that copies when bundling. In case you are using the feature to copy an
+ * npm module that, let's say, is not published, woopack will save that module (without its
+ * dependencies) on that folder.
  */
 
 /**
@@ -519,6 +633,25 @@
  */
 
 /**
+ * ================================================================================================
+ * Targets and other target related types
+ * ================================================================================================
+ */
+
+/**
+ * @typedef {BrowserTarget|NodeTarget} Target
+ */
+
+/**
+ * @typedef {function} TargetConfigurationCreator
+ * @param {string} overwritePath
+ * The path to the file that can create the configuration.
+ * @param {ConfigurationFile} baseConfiguration
+ * The configuration service that will be extended.
+ * @return {ConfigurationFile}
+ */
+
+/**
  * @typedef {function} BuildEngineGetCommand
  * @param {Target} target
  * The target information.
@@ -531,9 +664,21 @@
  */
 
 /**
+ * ================================================================================================
+ * "Interfaces"
+ * ================================================================================================
+ */
+
+/**
  * @typedef {Object} BuildEngine
  * @property {BuildEngineGetCommand} getBuildCommand
  * The method used by woopack in order to get the shell comands to build and/or run a target.
+ */
+
+/**
+ * ================================================================================================
+ * Others
+ * ================================================================================================
  */
 
 /**


### PR DESCRIPTION
### What does this PR do?

#### Paths and Output refactor

Instead of having a global setting for the output paths (`paths.output`), the option has been moved to the targets themselves:

```diff
 {
   paths: {
     source: 'src',
     build: 'dist',
     privateModules: 'private',
-    output: { ... }
   },
   targetsTemplates: {
     node: {
       ...,
+      output: {
+        default: '[target-name].js',
+        development: null,
+        production: null,
+      },
       ...,
     },
     browser: {
       ...,
+      output: {
+        default: {
+          js: 'statics/js/[target-name].[hash].js',
+          fonts: 'statics/fonts/[name].[hash].[ext]',
+          css: 'statics/styles/[target-name].[hash].css',
+          images: 'statics/images/[name].[hash].[ext]',
+        },
+        development: {
+          js: 'statics/js/[target-name].js',
+          fonts: 'statics/fonts/[name].[ext]',
+          css: 'statics/styles/[target-name].css',
+          images: 'statics/images/[name].[ext]',
+        },
+        production: null,
+      },
       ...,
     },
   }
 }
```

- This allows more control when working with multiple targets.
- They new options come with a `default` _"environment key"_ so you don't have to repeat everything when you want to use the same settings no matter the environment.
- You can use the following placeholders when building a path:
  - `[target-name]`: The name of the target.
  - `[hash]`: A random hash generated for cache busting.
  - `[name]`: The file original name (Only available on browser paths for `images` and `fonts`).
  - `[ext]`: The file original extension (Only available on browser paths for `images` and `fonts`).

#### Target's entry `default` option

Both types of targets now have a `entry.default` option that works as a fallback if an entry file is not defined for an environment.

Also, both targets types `entry` setting defaults now looks like this:

```js
entry: {
  default: 'index.js',
  development: null,
  production: null,
}
```
So, for browser targets that don't have its `entry` modified, this is not a breaking, for Node targets it is, as they previously had `start.development.js` and `start.production.js`.

#### Browser targets `html` new `default` option.

Similar to the change to the targets types `entry` setting, the default `html` settings of a browser target now look like this:

```js
{
  default: 'index.html',
  template: null,
  filename: null,
}
```
If you are using the same value for both and need to change it from `index.html`, you now can do it by modifying only one setting.

#### Browser targets dev server new options

`host` and `https` have been added to `.devServer` in case you want to specify a different host, that may or may not run on `https` for the target:

```diff
 devServer: {
   port: 2509,
   reload: true,
+  host: 'localhost',
+  https: false,
 }
```

> If you are wondering about adding certificates, well, that will come soon. For now `https` only affects the host URI.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```

